### PR TITLE
[CDP-1443] Bump json4s version to match AIQ and Spark

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,9 +24,11 @@ libraryDependencies += "io.spray" %% "spray-httpx" % "1.3.2"
 
 libraryDependencies += "io.spray" %% "spray-util" % "1.3.2"
 
-libraryDependencies += "org.json4s" %% "json4s-native" % "3.5.0"
+libraryDependencies += "org.json4s" %% "json4s-native" % "3.5.3"
 
-libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.5.0"
+libraryDependencies += "org.json4s" %% "json4s-core" % "3.5.3"
+
+libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.5.3"
 
 libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.5.26"
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,13 +10,11 @@ resolvers += "spray repo" at "http://repo.spray.io"
 
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
-
 scalacOptions in Test ++= Seq("-Yrangepos")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
-libraryDependencies += "io.spray" %% "spray-can" % "1.3.2"
+libraryDependencies += "org.scalaz.stream" %% "scalaz-stream" % "0.7.3"
 
 libraryDependencies += "io.spray" %% "spray-http" % "1.3.2"
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,8 @@ scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
 libraryDependencies += "org.scalaz.stream" %% "scalaz-stream" % "0.7.3"
 
+libraryDependencies += "io.spray" %% "spray-can" % "1.3.2"
+
 libraryDependencies += "io.spray" %% "spray-http" % "1.3.2"
 
 libraryDependencies += "io.spray" %% "spray-httpx" % "1.3.2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.1-SNAPSHOT"
+version in ThisBuild := "1.2.2-SNAPSHOT"


### PR DESCRIPTION
When testing Spark 2.4, I'm seeing this error in compile 

```
2021-05-13T20:41:06.975-0500 WARN [main] MetricClient  c= - StatsD metrics disabled in config.
java.lang.NoSuchMethodError: org.json4s.FieldSerializer.<init>(Lscala/PartialFunction;Lscala/PartialFunction;Lscala/reflect/Manifest;)V
	at github.gphat.datadog.Client.<init>(Client.scala:20)
	at co.actioniq.clients.datadog.DDClient.<init>(DDClient.scala:30)
	at co.actioniq.clients.datadog.DDAppClient.<init>(DDClient.scala:67)
	at co.actioniq.clients.datadog.DataDogApiClient$.apply(DataDogApiClient.scala:348)
```

I noticed gphat is using json4s 3.5.0 but AIQ references 3.2.11 and Spark references 3.5.3. I tried to force 3.5 on the AIQ side but it didnt work, so now I'm just changing it to 3.5.3 in all places.

Also it was looking for scalaz 0.6.x and that bintray url seems dead? So I removed it, and now its finding [0.7.3 on maven](https://mvnrepository.com/artifact/org.scalaz.stream/scalaz-stream).

### Test Plan
🤷 

### Deploy
`sbt publishLocal` and then copy `target/scala-2.11/*` to here 
```
$> aws s3 ls s3://aiq-artifacts/releases/com/github/gphat/datadog-scala_2.11/1.2.2-SNAPSHOT/

2021-05-13 21:05:21     375368 datadog-scala_2.11-1.2.2-SNAPSHOT-javadoc.jar
2021-05-13 21:05:28       4898 datadog-scala_2.11-1.2.2-SNAPSHOT-sources.jar
2021-05-13 21:05:36      73304 datadog-scala_2.11-1.2.2-SNAPSHOT.jar
2021-05-13 21:05:40       3768 datadog-scala_2.11-1.2.2-SNAPSHOT.pom
2021-05-13 21:18:58       2675 ivy-1.2.2-SNAPSHOT.xml
```